### PR TITLE
GameCard style

### DIFF
--- a/src/GameCard.css
+++ b/src/GameCard.css
@@ -35,10 +35,23 @@
   letter-spacing: 1.2px;
   /*text-shadow: 0px 2px 3px black;*/
   font-family: 'Audiowide', cursive;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 
 .text-container h4 {
   margin: 5px;
+}
+
+.text-container p {
+  margin: 0 0 0 50px;
+  color: #1a1d22;
+}
+
+.text-container p:hover {
+  cursor: pointer;
+  text-decoration: underline;
 }
 
 .add-to-library {
@@ -54,14 +67,20 @@
   transition: all .2s ease;
 }
 
-.add-to-libary:focus {
+.add-to-library:focus {
   outline: none;
 }
 
 .add-to-library:hover {
   background-color: rgb(206, 99, 255);
+  cursor: pointer;
 }
 
 .active-btn {
   background-color: rgb(206, 99, 255);
+}
+
+.add-to-library:active,
+.text-container p:active {
+  opacity: 0.5;
 }

--- a/src/GameCard.css
+++ b/src/GameCard.css
@@ -2,7 +2,7 @@
   background-color: rgba(80, 80, 80, .8);
   border-radius: 20px;
   display: flex;
-  height: 130px;
+  height: 90px;
   justify-content: space-between;
   margin: auto;
   width: 300px;
@@ -17,24 +17,27 @@
   align-items: center;
   display: flex;
   justify-content: center;
-  padding: 0 10px;
+  padding: 0 5px;
 }
 
 .gamecover {
-  border-radius: 10px;
+  border-radius: 15px;
   height: 110px;
   width: 80px;
+  height: 80px;
 }
 
 .text-container {
-  /* display: flex; */
-  /* align-content: center; */
   width: 100%;
   word-wrap: break-word;
   letter-spacing: 1.2px;
   text-shadow: 3px 2px 3px black;
   /* font-family: 'Righteous', cursive; */
   font-family: 'Audiowide', cursive;
+}
+
+.text-container h4 {
+  margin: 5px;
 }
 
 .add-to-library {
@@ -46,6 +49,7 @@
   color: white;
   font-size: 25px;
   height: 100%;
+  width: 45px;
 }
 
 button:focus {
@@ -54,7 +58,6 @@ button:focus {
 
 button:hover {
   background-color: rgb(206, 99, 255);
-  /* rgb(108, 52, 97) */
 }
 
 .active-btn {

--- a/src/GameCard.css
+++ b/src/GameCard.css
@@ -6,11 +6,13 @@
   justify-content: space-between;
   margin: auto;
   width: 300px;
-  box-shadow: 3px 2px 3px black, 3.5px 3.2px 3.5px #613941;
+  /*box-shadow: 3px 2px 3px black, 3.5px 3.2px 3.5px #613941;*/
+  transition: all .2s ease;
 }
 
 .game-card:hover {
-  box-shadow: 3px 2px 3px black, 4px 4px 4px rgb(206, 99, 255);
+  /*box-shadow: 3px 2px 3px black, 4px 4px 4px rgb(206, 99, 255);*/
+  box-shadow: 0px 4px 18px rgb(206, 99, 255);
 }
 
 .img {
@@ -31,8 +33,7 @@
   width: 100%;
   word-wrap: break-word;
   letter-spacing: 1.2px;
-  text-shadow: 3px 2px 3px black;
-  /* font-family: 'Righteous', cursive; */
+  /*text-shadow: 0px 2px 3px black;*/
   font-family: 'Audiowide', cursive;
 }
 
@@ -50,13 +51,14 @@
   font-size: 25px;
   height: 100%;
   width: 45px;
+  transition: all .2s ease;
 }
 
-button:focus {
+.add-to-libary:focus {
   outline: none;
 }
 
-button:hover {
+.add-to-library:hover {
   background-color: rgb(206, 99, 255);
 }
 

--- a/src/GameCard.js
+++ b/src/GameCard.js
@@ -7,16 +7,19 @@ export default class GameCard extends Component {
     this.state = { expanded: false };
   }
   render() {
+    let inLibraryStatus = " + "
+    const style = { backgroundImage: 'url(' + this.props.img + ')', backgroundSize: 'cover' };
     return(
       <div className="game-card">
         <section className="img">
-          <img className="gamecover" src={this.props.img} alt="not avail" />
+          <div className="gamecover" style={style}></div>
+          {/*<img className="gamecover" src={this.props.img} alt="not avail" />*/}
         </section>
         <section className="text-container">
           <h4>{this.props.name}</h4>
         </section>
         <section className="btn">
-          <button className="add-to-library"> + </button>
+          <button className="add-to-library"> {inLibraryStatus} </button>
         </section>
       </div>
     )

--- a/src/GameCard.js
+++ b/src/GameCard.js
@@ -13,7 +13,6 @@ export default class GameCard extends Component {
       <div className="game-card">
         <section className="img">
           <div className="gamecover" style={style}></div>
-          {/*<img className="gamecover" src={this.props.img} alt="not avail" />*/}
         </section>
         <section className="text-container">
           <h4>{this.props.name}</h4>

--- a/src/GameCard.js
+++ b/src/GameCard.js
@@ -16,9 +16,10 @@ export default class GameCard extends Component {
         </section>
         <section className="text-container">
           <h4>{this.props.name}</h4>
+          <p>More Info..</p>
         </section>
         <section className="btn">
-          <button className="add-to-library"> {inLibraryStatus} </button>
+          <button className="add-to-library">{inLibraryStatus}</button>
         </section>
       </div>
     )


### PR DESCRIPTION
Changed GameCard styling:
- Removed the double box-shadow (personal preference, let me know what you guys prefer)
- Added transitions
- Added a "more info" button
- Slightly changed the sizing of the card
- Changed the way that images are appended. They now use a background-image attribute to avoid compression
- Slightly changed the size of images.
@SiimonStark 
@DekayHaHa 
Let me know what you guys think of the changes. I tried to make everything a little bit cleaner but I'm open to any other suggestions as well